### PR TITLE
Changed Endpoints data structure

### DIFF
--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -1,12 +1,8 @@
-import { Endpoints } from '../types/endpoints';
-import {
-  formatParamsToQueryString,
-  FormatParamsInput,
-  buildQueryUrl,
-} from '../utils/query-builder';
+import { formatParamsToQueryString, buildQueryUrl } from '../utils/query-builder';
+import { ENDPOINTS } from '../types/endpoints';
 
 describe('Object To Query String Test Suite', () => {
-  const queryStringInput: FormatParamsInput = {
+  const queryStringInput: Record<string, number | string> = {
     page: 2,
     page_size: 1,
     search: 'AT-AT',
@@ -33,13 +29,15 @@ describe('Object To Query String Test Suite', () => {
 });
 
 describe('Build Query URL Test Suite', () => {
-  const inputNoParams = { endpoint: Endpoints.Sets };
+  const inputNoParams = { endpoint: ENDPOINTS.SETS.BASE };
+
   const inputNoSetNum = {
-    endpoint: Endpoints.Sets,
+    endpoint: ENDPOINTS.SETS.BASE,
     params: { page_size: 1 },
   };
+
   const inputFull = {
-    endpoint: Endpoints.MinifigParts,
+    endpoint: ENDPOINTS.MINIFIGS.PARTS,
     params: { page_size: 1 },
     identifier: { key: 'set_num', value: '111-111' },
   };

--- a/src/api/set.api.ts
+++ b/src/api/set.api.ts
@@ -2,7 +2,7 @@ import { AxiosError, AxiosResponse } from 'axios';
 
 import { buildQueryUrl } from '../utils/query-builder';
 import { BaseApiClass } from './base.api';
-import { Endpoints } from '../types';
+import { ENDPOINTS } from '../types';
 import {
   APIResourceList,
   ListSetsInput,
@@ -23,7 +23,7 @@ import {
 export class SetApiClass extends BaseApiClass {
   public async getSets(params: ListSetsInput = {}): Promise<APIResourceList<Set>> {
     const url = buildQueryUrl({
-      endpoint: Endpoints.Sets,
+      endpoint: ENDPOINTS.SETS.BASE,
       params: { ...params },
     });
 
@@ -38,7 +38,7 @@ export class SetApiClass extends BaseApiClass {
   }
 
   public async getSetBySetNum(set_num: string): Promise<Set> {
-    const url = `${Endpoints.Sets}/${set_num}`;
+    const url = `${ENDPOINTS.SETS.BASE}/${set_num}`;
 
     if (!url) throw new Error('Invalid URL parameters');
 
@@ -55,7 +55,7 @@ export class SetApiClass extends BaseApiClass {
     params?: SetsAlternatesInput
   ): Promise<APIResourceList<SetAlternates>> {
     const url = buildQueryUrl({
-      endpoint: Endpoints.SetsAlternates,
+      endpoint: ENDPOINTS.SETS.ALTERNATES,
       params: { ...params },
       identifier: { key: 'set_num', value: set_num },
     });
@@ -75,7 +75,7 @@ export class SetApiClass extends BaseApiClass {
     params?: SetsMinifigInput
   ): Promise<APIResourceList<SetMinifigs>> {
     const url = buildQueryUrl({
-      endpoint: Endpoints.SetsMinifigs,
+      endpoint: ENDPOINTS.SETS.MINIFIGS,
       params: { ...params },
       identifier: { key: 'set_num', value: set_num },
     });
@@ -95,7 +95,7 @@ export class SetApiClass extends BaseApiClass {
     params?: SetsPartsInput
   ): Promise<APIResourceList<SetParts>> {
     const url = buildQueryUrl({
-      endpoint: Endpoints.SetsParts,
+      endpoint: ENDPOINTS.SETS.PARTS,
       params: { ...params },
       identifier: { key: 'set_num', value: set_num },
     });
@@ -119,7 +119,7 @@ export class SetApiClass extends BaseApiClass {
     params?: SetsInventoryInput
   ): Promise<APIResourceList<Set>> {
     const url = buildQueryUrl({
-      endpoint: Endpoints.SetsSets,
+      endpoint: ENDPOINTS.SETS.SETS,
       params: { ...params },
       identifier: { key: 'set_num', value: set_num },
     });

--- a/src/types/endpoints.ts
+++ b/src/types/endpoints.ts
@@ -1,34 +1,96 @@
 /**
  * Rebrickable API endpoints for wrapping
  */
-export enum Endpoints {
-  'Colors' = '/lego/colors',
-  'Elements' = '/lego/elements',
-  'Themes' = '/lego/themes',
-  'Minifigs' = '/lego/minifigs',
-  'MinifigParts' = '/lego/minifigs/:set_num/parts',
-  'MinifigSets' = '/lego/minifigs/:set_num/sets',
-  'Parts' = '/lego/parts',
-  'PartColors' = '/lego/parts/:part_num/colors',
-  'PartColorsSets' = '/lego/parts/:part_num/colors/:color_id/sets',
-  'PartCategories' = '/lego/part_categories',
-  'Sets' = '/lego/sets',
-  'SetsAlternates' = '/lego/sets/:set_num/alternates',
-  'SetsMinifigs' = '/lego/sets/:set_num/minifigs',
-  'SetsParts' = '/lego/sets/:set_num/parts',
-  'SetsSets' = '/lego/sets/:set_num/sets',
-  'UserBadges' = '/users/badges',
-  'UserToken' = '/users/_token',
-  'UserAllParts' = '/users/:user_token/allparts',
-  'UserBuild' = '/users/:user_token/build',
-  'UserLostParts' = '/users/:user_token/lost_parts',
-  'UserMinifigs' = '/users/:user_token/minifigs',
-  'UserPartLists' = '/users/:user_token/partlists',
-  'UserPartListParts' = '/users/:user_token/partlists/:list_id/parts',
-  'UserParts' = '/users/:user_token/parts',
-  'UserProfile' = '/users/:user_token/profile',
-  'UserSetLists' = '/users/:user_token/setlists',
-  'UserSetListSets' = '/users/:user_token/setlists/:list_id/sets',
-  'UserSets' = '/users/:user_token/sets',
-  'UserSetSync' = '/users/:user_token/sets/sync',
+export enum Colors {
+  BASE = '/lego/colors',
 }
+
+export enum Elements {
+  BASE = '/lego/elements',
+}
+
+export enum Themes {
+  BASE = '/lego/themes',
+}
+
+export enum Sets {
+  BASE = '/lego/sets',
+  SETS = '/lego/sets/:set_num/sets',
+  PARTS = '/lego/sets/:set_num/parts',
+  MINIFIGS = '/lego/sets/:set_num/minifigs',
+  ALTERNATES = '/lego/sets/:set_num/alternates',
+}
+
+export enum Minifigs {
+  BASE = '/lego/minifigs',
+  PARTS = '/lego/minifigs/:set_num/parts',
+  SETS = '/lego/minifigs/:set_num/sets',
+}
+
+export enum Parts {
+  BASE = '/lego/parts',
+  COLORS = '/lego/parts/:part_num/colors',
+  COLORSETS = '/lego/parts/:part_num/colors/:color_id/sets',
+}
+
+export enum PartCategories {
+  BASE = '/lego/part_categories',
+}
+
+export enum UserBadges {
+  BASE = '/users/badges',
+}
+
+export enum UserToken {
+  BASE = '/users/_token',
+}
+
+export enum UserParts {
+  BASE = '/users/:user_token/parts',
+  LOST = '/users/:user_token/lost_parts',
+  ALLPARTS = '/users/:user_token/allparts',
+  LIST = '/users/:user_token/partlists',
+  LISTPARTS = '/users/:user_token/partlists/:list_id/parts',
+}
+
+export enum UserBuild {
+  BASE = '/users/:user_token/build',
+}
+
+export enum UserMinifigs {
+  BASE = '/users/:user_token/minifigs',
+}
+
+export enum UserProfile {
+  BASE = '/users/:user_token/profile',
+}
+
+export enum UserSetLists {
+  BASE = '/users/:user_token/setlists',
+  SETS = '/users/:user_token/setlists/:list_id/sets',
+}
+
+export enum UserSets {
+  BASE = '/users/:user_token/sets',
+  SYNC = '/users/:user_token/sets/sync',
+}
+
+export const ENDPOINTS = {
+  COLORS: Colors,
+  SETS: Sets,
+  MINIFIGS: Minifigs,
+  ELEMENTS: Elements,
+  THEMES: Themes,
+  PARTS: Parts,
+  PARTCATEGORIES: PartCategories,
+  USER: {
+    BADGES: UserBadges,
+    TOKEN: UserToken,
+    PARTS: UserParts,
+    BUILD: UserBuild,
+    MINIFIGS: UserMinifigs,
+    PROFILE: UserProfile,
+    SETLISTS: UserSetLists,
+    SETS: UserSets,
+  },
+};

--- a/src/utils/query-builder.ts
+++ b/src/utils/query-builder.ts
@@ -1,7 +1,3 @@
-export interface FormatParamsInput {
-  [index: string]: number | string;
-}
-
 export interface Indentifier {
   key: string;
   value: number | string;
@@ -9,13 +5,13 @@ export interface Indentifier {
 
 export interface BuildQueryInput {
   endpoint: string;
-  params?: FormatParamsInput;
+  params?: Record<string, number | string>;
   identifier?: Indentifier;
 }
 
-export type FormatParamsOutput = string | undefined;
-
-export const formatParamsToQueryString = (params: FormatParamsInput): FormatParamsOutput => {
+export const formatParamsToQueryString = (
+  params: Record<string, number | string>
+): string | undefined => {
   if (params.constructor !== Object) return undefined;
 
   const keys = Object.keys(params);


### PR DESCRIPTION
Refactored the endpoints data structure into a number of logically grouped enums with, at minimum, a `BASE` endpoint.

e.g 1:
```
export enum Colors {
  BASE = '/lego/colors',
}
```

e.g 2:
```
export enum Sets {
  BASE = '/lego/sets',
  SETS = '/lego/sets/:set_num/sets',
  PARTS = '/lego/sets/:set_num/parts',
  MINIFIGS = '/lego/sets/:set_num/minifigs',
  ALTERNATES = '/lego/sets/:set_num/alternates',
}
```

These are collated in a literal object for referencing in the codebase.